### PR TITLE
Typo in requirements.txt scikit-learn was spelt wrong?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 scipy
 pandas
 matplotlib
-skikit-learn
+scikit-learn
 obspy
 NonLinLocPy


### PR DESCRIPTION
Hi Tom,

I think i found a typo in the requirements.txt whilst making the SKS example figs

"Sci-kitlearn" was spelt as "skikit-learn"