### PR TITLE
Test angles

### DIFF
--- a/swspy/__init__.py
+++ b/swspy/__init__.py
@@ -9,6 +9,7 @@ __email__ = "thomas.hudson@earth.ox.ac.uk"
 from swspy import io
 from swspy import splitting
 from swspy import automate 
+from . import testing
 #from swspy import plot
 # from swspy.io import *
 # from swspy.splitting import *

--- a/swspy/testing.py
+++ b/swspy/testing.py
@@ -2,12 +2,13 @@
 
 import numpy as np
 
-def clamp_angle(angle):
+def clamp_angle(angle_in):
     """
     Assuming 180 degree periodicity, represent an angle between -90 and +90 degrees
 
     angle is a numpy array.
     """
+    angle = np.atleast_1d(angle_in)
     angle = angle - 180.0 * np.fix(angle / 180.0)
     angle[angle<=-90.0] = angle[angle<=-90.0] + 180.0
     angle[angle>90.0] = angle[angle>90.0] - 180.0

--- a/swspy/testing.py
+++ b/swspy/testing.py
@@ -1,0 +1,40 @@
+# Helper functions for testing swspy
+
+import numpy as np
+
+def clamp_angle(angle):
+    """
+    Assuming 180 degree periodicity, represent an angle between -90 and +90 degrees
+
+    angle is a numpy array.
+    """
+    angle = angle - 180.0 * np.fix(angle / 180.0)
+    angle[angle<=-90.0] = angle[angle<=-90.0] + 180.0
+    angle[angle>90.0] = angle[angle>90.0] - 180.0
+
+    return angle
+
+
+def periodic_angular_difference(a_angle, b_angle):
+    """
+    Angular difference assuming 180 degree periodicity
+    
+    a_angle and b_angle are numpy arrays of angle, retuns a numpy array of
+    differences such that 0.0 and 360.0 and 180.0 are all the same.
+    """
+    difference = np.minimum(np.fabs(a_angle - b_angle), 
+                       np.fabs(clamp_angle(a_angle) - clamp_angle(b_angle)))
+    return difference
+
+
+def assert_angle_allclose(actual, desired, **kwargs):
+    """
+    Raises an AssertionError if two objects are not equal accounting for angle
+
+    This wraps numpy.testing.assert_allclose but values such as 0.0, 360.0 and
+    180.0 are all treated as being the same. Keyword arguments are passed
+    on.
+    """
+    diff = periodic_angular_difference(actual, desired)
+    real_desired = np.zeros_like(desired)
+    np.testing.assert_allclose(diff, real_desired, **kwargs)

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -66,8 +66,7 @@ def test_single_synthetic(dt, phi_N, src_pol_N, src_pol_U, snr):
     lam2_lam1 = splitting_event.sws_result_df['lambda2/lambda1 ratio'].values[0]
 
     assert(lam2_lam1 >= 0.0)
-    # What about 180 degree errors or around 0
-    numpy.testing.assert_allclose(phi_N, phi_N_res, rtol=0.0, atol=phi_err_res)
+    swspy.testing.assert_angle_allclose(phi_N, phi_N_res, rtol=0.0, atol=phi_err_res)
     numpy.testing.assert_allclose(dt, dt_res, rtol=0.0, atol=dt_err_res)
     
     

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -1,0 +1,40 @@
+# Test cases for testing
+# 
+# We have some testing helpers. These tests test that the testing helpers
+# work. It's good if they do. Or we know if they don't.
+
+import pytest
+import numpy as np
+import swspy
+
+
+def test_clamp_angle():
+
+    ins = np.array((90.0, -89.9, 91.0, -90.0, -91.0, 0.0, 359.0, 360.0, 1.0))
+    outs = np.array((90.0, -89.9, -89.0, 90.0, 89.0, 0.0, -1.0, 0.0, 1.0)) 
+
+    calc_outs = swspy.testing.clamp_angle(ins)
+    np.testing.assert_allclose(outs, calc_outs)
+     
+
+def test_periodic_angular_difference():
+
+    a_in = np.array([359, 89, 179, 271, 0.0, 90.0, -90.0, 360.0])
+    b_in = np.array([1, 91, 181, 269, 180.0, -90.0, 90.0, 180.0])
+    diff_in = np.array([2., 2., 2., 2., 0., 0., 0., 0.])
+    diff = swspy.testing.periodic_angular_difference(a_in, b_in)
+    np.testing.assert_allclose(diff_in, diff)
+
+
+def test_assert_angle_allclose_close():
+
+    a_in = np.array([359, 89, 179, 271, 0.0, 90.0, -90.0, 360.0])
+    b_in = np.array([1, 91, 181, 269, 180.0, -90.0, 90.0, 180.0])
+    swspy.testing.assert_angle_allclose(a_in, b_in, atol=2.1, rtol=0.0)
+
+
+def test_assert_angle_allclose_raises():
+    a_in = np.array([0.0, 45.0, 90.0])
+    b_in = np.array([30.0, 30.0, 30.0])
+    with pytest.raises(AssertionError):
+        swspy.testing.assert_angle_allclose(a_in, b_in)


### PR DESCRIPTION
This creates a new 'swspy.testing' submodule with helper functions for tests. The main one of these is a wrapper around np.assert_all_close that accounts for 180 degree periodicity in angular data. We can thus test a wider range of SWS cases without worrying about results that are at opposite sides of the branch cut.